### PR TITLE
Reset gem version for CD pipeline

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,7 @@
       ]
     }
   },
+  "initial-version": "0.1.0",
   "plugins": [
     {
       "type": "sentence-case"


### PR DESCRIPTION
Tell release-please that the initial version of the gem should be 0.1.0 instead of 1.0.0.