### PR TITLE
Rename the `target_exist?` option to `target_exist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ expect(path).to have_dir(
 )
 
 expect(path).to have_symlink(
-  name, mode:, owner:, group:, ctime:, mtime:, target:, target_type:, dangling:
+  name, mode:, owner:, group:, ctime:, mtime:, target:, target_type:, target_exist:
 )
 ```
 

--- a/design.rb
+++ b/design.rb
@@ -11,7 +11,7 @@ expect(path).to have_dir(
 )
 
 expect(path).to have_symlink(
-  name, mode:, owner:, group:, ctime:, mtime:, target:, target_type:, dangling:
+  name, mode:, owner:, group:, ctime:, mtime:, target:, target_type:, target_exist:
 )
 
 ########################################
@@ -73,4 +73,4 @@ expect(path).to have_symlink(name, mtime: timestamp_matcher) # ...the symlink mo
 
 expect(path).to have_symlink(name, target: target_matcher) # ...the symlink target as a String
 expect(path).to have_symlink(name, target_type: target_type)
-expect(path).to have_symlink(name, target_exist?: boolean) # Assert whether the symlink is dangling or not
+expect(path).to have_symlink(name, target_exist: boolean) # Assert whether the symlink is target_exist or not

--- a/lib/rspec/path_matchers/options/symlink_target_exist.rb
+++ b/lib/rspec/path_matchers/options/symlink_target_exist.rb
@@ -5,7 +5,7 @@ module RSpec
     module Options
       # target_exist: <expected>
       class SymlinkTargetExist
-        def self.key = :target_exist?
+        def self.key = :target_exist
 
         def self.description(expected)
           RSpec::PathMatchers.matcher?(expected) ? expected.description : expected.to_s

--- a/spec/rspec/file_system/have_symlink_spec.rb
+++ b/spec/rspec/file_system/have_symlink_spec.rb
@@ -863,13 +863,13 @@ RSpec.describe 'the have_symlink matcher' do
   end
 
   describe 'the target_exist: option' do
-    subject { expect(tmpdir).to have_symlink(expected_name, target_exist?: expected_target_exist) }
+    subject { expect(tmpdir).to have_symlink(expected_name, target_exist: expected_target_exist) }
 
     context 'when the expected target exist is not valid' do
       let(:expected_target_exist) { 123 }
 
       it 'should raise an ArgumentError' do
-        expected_message = /expected `target_exist\?:` to be a Matcher, true, or false but was 123/
+        expected_message = /expected `target_exist:` to be a Matcher, true, or false but was 123/
         expect { subject }.to raise_error(ArgumentError, expected_message)
       end
     end
@@ -888,7 +888,7 @@ RSpec.describe 'the have_symlink matcher' do
       context 'when the expected target type does not match the actual target type' do
         it 'should fail' do
           FileUtils.rm_rf(target_path)
-          expected_message = /expected target_exist\? to be true, but was false/
+          expected_message = /expected target_exist to be true, but was false/
           expect { subject }.to raise_error(expectation_not_met_error, expected_message)
         end
       end
@@ -908,7 +908,7 @@ RSpec.describe 'the have_symlink matcher' do
       context 'when the expected target type does not match the actual target type' do
         it 'should fail' do
           FileUtils.rm_rf(target_path)
-          expected_message = /expected target_exist\? to equal true, but was false/
+          expected_message = /expected target_exist to equal true, but was false/
           expect { subject }.to raise_error(expectation_not_met_error, expected_message)
         end
       end


### PR DESCRIPTION
Keyword parameters can not end in a question mark.