### PR TITLE
feat: add the be_dir matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RSpec.describe 'Generated Project' do
     project_dir = Dir.pwd
 
     expect(project_dir).to(
-      have_dir(".") do
+      be_dir do
         file("README.md", content: /MyProject/, birthtime: within(10_000).of(Time.now))
         dir("lib", exact: true) do
           file("my_project.rb")
@@ -52,6 +52,23 @@ RSpec.describe 'Generated Project' do
     )
   end
 end
+```
+
+Coming soon. Plan to change the interface to use `containing` or `containing_exactly` rather than
+nested blocks and the `exact:` option:
+
+```ruby
+expect(project_dir).to(
+  be_dir.containing(
+    file("README.md", content: /MyProject/, birthtime: within(10_000).of(Time.now)),
+    dir("lib").containing_exactly(
+      file("my_project.rb"),
+      dir("my_project").containing_exactly(
+        file("version.rb", content: include('VERSION = "0.1.0"'), size: be < 1000)
+      )
+    )
+  )
+)
 ```
 
 ## Added Value

--- a/lib/rspec/path_matchers.rb
+++ b/lib/rspec/path_matchers.rb
@@ -22,14 +22,18 @@ require_relative 'path_matchers/matchers/have_no_entry'
 
 require_relative 'path_matchers/refinements'
 
+def be_dir(**options_hash, &)
+  RSpec::PathMatchers::Matchers::HaveDirectory.new('', matcher_name: __method__, **options_hash, &)
+end
+
 def have_file(name, **options_hash) # rubocop:disable Naming/PredicatePrefix
-  RSpec::PathMatchers::Matchers::HaveFile.new(name, **options_hash)
+  RSpec::PathMatchers::Matchers::HaveFile.new(name, matcher_name: __method__, **options_hash)
 end
 
 def have_dir(name, **options_hash, &) # rubocop:disable Naming/PredicatePrefix
-  RSpec::PathMatchers::Matchers::HaveDirectory.new(name, **options_hash, &)
+  RSpec::PathMatchers::Matchers::HaveDirectory.new(name, matcher_name: __method__, **options_hash, &)
 end
 
 def have_symlink(name, **options_hash) # rubocop:disable Naming/PredicatePrefix
-  RSpec::PathMatchers::Matchers::HaveSymlink.new(name, **options_hash)
+  RSpec::PathMatchers::Matchers::HaveSymlink.new(name, matcher_name: __method__, **options_hash)
 end

--- a/lib/rspec/path_matchers/matchers/base.rb
+++ b/lib/rspec/path_matchers/matchers/base.rb
@@ -4,14 +4,102 @@ module RSpec
   module PathMatchers
     module Matchers
       # The base class for matchers
+      #
+      # Implements the [RSpec matcher
+      # protocol](https://rspec.info/documentation/3.13/rspec-expectations/RSpec/Matchers/MatcherProtocol.html)
+      # for value expectations including:
+      #
+      # - `#matches?(base_path)` - checks if the matcher matches the given base_path
+      # - `#failure_message` - returns a human-readable failure message
+      # - `#actual` - returns the actual value that was matched against
+      # - `#expected` - returns the expected value that was matched against
+      # - `#description` - returns a human-readable description of the matcher
+      # - `#does_not_match?(base_path)` - checks if the matcher does not match the given base_path
+      # - `#failure_message_when_negated` - returns a human-readable failure message for negative matches
+      #
       class Base # rubocop:disable Metrics/ClassLength
-        def initialize(name, **options_hash)
+        # Create a new matcher instance
+        #
+        # Subclasses may override this to provide additional arguments or options.
+        # They should call `super` to ensure the base class is initialized correctly.
+        #
+        # @param entry_name [String] The name of the entry to match against
+        #
+        #   - If entry_name is empty, the matcher will match against the base_path
+        #     directly
+        #   - If entry_name is NOT empty, the matcher will match against
+        #     File.join(base_path, entry_name)
+        #
+        # @param matcher_name [Symbol] The matcher name (e.g. :have_dir, :have_file,
+        #   etc.) to use in descriptions and messages
+        #
+        # @param options_hash [Hash] Options for the matcher passed to the options
+        #   factory to get an options object
+        #
+        def initialize(entry_name, matcher_name:, **options_hash)
           super()
-          @name = name.to_s
+          @entry_name = entry_name.to_s
+          @matcher_name = matcher_name
           @options = options_factory(*option_keys, **options_hash)
+          @failure_messages = []
         end
 
-        attr_reader :name, :options, :base_path, :path
+        # @attribute [r] options
+        #
+        # The matcher options loaded from the options_hash passed to the initializer
+        #
+        # @return [Object] A Data object containing the options
+        #
+        attr_reader :options
+
+        # @attribute [r] base_path
+        #
+        # The base path against which the matcher is applied
+        #
+        # @return [String]
+        #
+        attr_reader :base_path
+
+        # @attribute [r] path
+        #
+        # The full path to the entry being matched against
+        #
+        # @return [String]
+        #
+        attr_reader :path
+
+        # @attribute [r] matcher_name
+        #
+        # The name of this matcher, used for descriptions and messages
+        #
+        # @return [Symbol] The matcher name (e.g. :have_dir, :have_file, etc.)
+        #
+        attr_reader :matcher_name
+
+        # @attribute [r] failure_messages
+        #
+        # An array of failure messages that describe why the matcher did not match
+        # the actual value
+        #
+        # Only populated after `matches?` or `execute_match` is called
+        #
+        # @return [Array<String>]
+        #
+        attr_reader :failure_messages
+
+        # @attribute [r] entry_name
+        #
+        # The name of the entry being matched against or an empty String
+        #
+        # If `entry_name` is empty, the matcher will match against the base_path
+        # directly. If `entry_name` is not empty, the matcher will match against
+        # `File.join(base_path, entry_name)`.
+        #
+        # @return [String]
+        #
+        def entry_name
+          @entry_name || base_path.basename
+        end
 
         # A human-readable description of the matcher's expectation
         #
@@ -20,25 +108,31 @@ module RSpec
         # have_file("foo")` and the file does not exist, the failure message will
         # include the output of this method: "expected to have file \"foo\"".
         #
+        # Subclasses can override this method to add to or provide a more specific
+        # description based on the entry type, options, or other factors.
+        #
         # @return [String] A description of the matcher
         #
         def description
-          desc = "have #{entry_type} #{name.inspect}"
+          desc = (@entry_name.empty? ? "be a #{entry_type}" : "have #{entry_type} #{entry_name.inspect}")
           options_description = build_options_description
           desc += " with #{options_description}" unless options_description.empty?
           desc
         end
 
-        def failure_messages
-          @failure_messages ||= []
-        end
-
+        # Returns `true` if the matcher matches the actual value
+        #
+        # If `false` is returned, the `failure_messages` array will be populated with
+        # human-readable error messages that describe why the match failed.
+        #
+        # @param base_path [Object] The base_path together with entry_name determine the actual value
+        #
+        # @return [Boolean] `true` if the matcher matches, `false` otherwise
+        #
+        # @raise [ArgumentError] if there are errors in the matcher or its options
+        #
         def matches?(base_path)
-          # It is important to reset failure_messages in case this matcher instance
-          # is reused
-          @failure_messages = []
-
-          # Phase 1: Validate all options recursively for syntax errors
+          # Phase 1: Validate all options for syntax errors
           validation_errors = []
           collect_validation_errors(validation_errors)
           raise ArgumentError, validation_errors.join(', ') if validation_errors.any?
@@ -47,49 +141,8 @@ module RSpec
           execute_match(base_path)
         end
 
-        def collect_negative_validation_errors(errors)
-          errors << "The matcher `not_to #{matcher_name}(...)` cannot be given options" if options.any_given?
-        end
-
-        # This method is called by RSpec for `expect(...).not_to have_...`
-        def does_not_match?(base_path) # rubocop:disable Naming/PredicatePrefix
-          # 1. Validate that no options were passed to the negative matcher.
-          validation_errors = []
-          collect_negative_validation_errors(validation_errors)
-          raise ArgumentError, validation_errors.join(', ') if validation_errors.any?
-
-          @base_path = base_path.to_s
-          @path = File.join(base_path, name)
-
-          # 2. A negative match SUCCEEDS if the entry of the specified type does NOT exist.
-          #    We delegate the type-specific check to the subclass.
-          #    The method returns `true` if the entry is NOT of the correct type (pass),
-          #    and `false` if it IS of the correct type (fail).
-          !correct_type?
-        end
-
-        # This is the message RSpec will display if `does_not_match?` returns `false`.
-        def failure_message_when_negated
-          "expected it not to be a #{entry_type}"
-        end
-
-        # Recursively gathers all syntax/validation errors
-        #
-        # Subclasses (like HaveDirectory) may extend this to recurse into nested
-        # matchers.
-        #
-        # @param errors [Array<String>] An array to append validation error messages to.
-        #
-        # @return [void]
-        #
-        # @api private
-        #
-        def collect_validation_errors(errors)
-          validate_option_values(errors)
-        end
-
         def failure_message
-          header = "the entry '#{name}' at '#{base_path}' was expected to satisfy the following but did not:"
+          header = "the entry '#{entry_name}' at '#{base_path}' was expected to satisfy the following but did not:"
           # Format single- and multi-line nested messages with proper indentation.
           messages = failure_messages.map do |msg|
             msg.lines.map.with_index do |line, i|
@@ -99,29 +152,106 @@ module RSpec
           "#{header}\n#{messages}"
         end
 
-        def correct_type?
-          raise NotImplementedError, 'This method should be implemented in a subclass'
+        # This method is called by RSpec for `expect(...).not_to have_...`
+        def does_not_match?(base_path) # rubocop:disable Naming/PredicatePrefix
+          # Phase 1: Validate all options for syntax errors (in this case options are not allowed)
+          validation_errors = []
+          collect_negative_validation_errors(validation_errors)
+          raise ArgumentError, validation_errors.join(', ') if validation_errors.any?
+
+          @base_path = base_path.to_s
+          @path = @entry_name.empty? ? base_path : File.join(base_path, entry_name)
+
+          # Phase 2: Execute the actual match logic
+          #
+          # A negative match SUCCEEDS if the entry of the specified type does NOT
+          # exist. We delegate the type-specific check to the subclass.
+          !correct_type?
         end
 
-        def matcher_name
-          raise NotImplementedError, 'This method should be implemented in a subclass'
+        # This is the message RSpec will display if `does_not_match?` returns `false`.
+        def failure_message_when_negated
+          "expected it not to be a #{entry_type}"
         end
 
         protected
 
+        # Add to `errors` if the matcher is not defined correctly
+        #
+        # Subclasses may override this method to provide additional checking. For
+        # instance, HaveDirectory extends this to add validation for nested matchers.
+        #
+        # A nesting matcher (such as HaveDirectory) may call this method on the
+        # nested matchers to collect all validation errors before raising an
+        # ArgumentError.
+        #
+        # @param errors [Array<String>] An array to populate with validation error
+        # messages
+        #
+        # @return [void]
+        #
+        # @api private
+        #
+        def collect_validation_errors(errors)
+          validate_option_values(errors)
+        end
+
+        # Returns `true` if `path` exists and is of the correct type for this matcher
+        #
+        # Subclasses must implement this method to check the type of the entry. For
+        # example, HaveFile checks if the path is a regular file; HaveDirectory, a
+        # directory; and HaveSymlink, a symlink.
+        #
+        # @return [Boolean]
+        #
+        # @abstract
+        #
+        def correct_type?
+          raise NotImplementedError, 'Subclasses must implement Base#correct_type?'
+        end
+
+        # Add to errors if options were passed to the negative matcher
+        #
+        # This method is called by RSpec for `expect(...).not_to <matcher>...`
+        #
+        # Subclasses can override this to add additional validation.
+        #
+        # @param errors [Array<String>] An array to append validation error messages to
+        #
+        # @return [void]
+        #
+        def collect_negative_validation_errors(errors)
+          errors << "The matcher `not_to #{matcher_name}(...)` cannot be given options" if options.any_given?
+        end
+
+        # Subclasses should define their own option definitions
+        #
+        # @return [Array<RSpec::PathMatchers::Options::Base>] An array of option definitions
+        #
+        def option_definitions = []
+
+        # The type of entry this matcher is checking for
+        #
+        # @return [Symbol] The entry type (e.g. :file, :directory, :symlink, ...)
+        #
         def entry_type
-          self.class.name.split('::').last.sub(/^Have/, '').downcase
+          raise NotImplementedError, 'Subclasses must implement Base#entry_type'
         end
 
         # Performs the actual matching against the directory entry
         #
         # This method assumes that collect_validation_errors has already been called
-        # and passed. This method is protected so that container matchers (like
-        # HaveDirectory) can call it on nested matchers without using .send.
+        # and passed.
+        #
+        # This method is protected so that container matchers (like HaveDirectory)
+        # can call it on nested matchers without using .send.
         #
         def execute_match(base_path) # rubocop:disable Naming/PredicateMethod
+          # It is important to reset failure_messages in case this matcher is reused
+          @failure_messages = []
+
           @base_path = base_path.to_s
-          @path = File.join(base_path, name)
+          @path = @entry_name.empty? ? base_path : File.join(base_path, entry_name)
 
           # Validate existence and type.
           validate_existance(failure_messages)
@@ -177,12 +307,14 @@ module RSpec
         end
 
         def validate_existance(_failure_messages)
-          raise NotImplementedError, 'This method should be implemented in a subclass'
+          raise NotImplementedError, 'Subclasses must implement Base#validate_existance'
         end
 
         # Validate the options for the current matcher
         #
-        # Subclasses will override this to add nested execution.
+        # Subclasses may override this to add additional validation logic. For
+        # instance, HaveDirectory extends this to check nested matchers.
+        #
         def validate_options
           options.members.each do |key|
             expected = options.send(key)

--- a/lib/rspec/path_matchers/matchers/directory_contents_inspector.rb
+++ b/lib/rspec/path_matchers/matchers/directory_contents_inspector.rb
@@ -24,32 +24,34 @@ module RSpec
 
         # Defines an expectation for a file within the directory.
         def file(name, **)
-          nested_matchers << RSpec::PathMatchers::Matchers::HaveFile.new(name, **)
+          nested_matchers << RSpec::PathMatchers::Matchers::HaveFile.new(name, matcher_name: __method__, **)
         end
 
         # Defines an expectation for a nested directory.
-        def dir(name, ...)
-          nested_matchers << RSpec::PathMatchers::Matchers::HaveDirectory.new(name, ...)
+        def dir(name, **options_hash, &)
+          nested_matchers << RSpec::PathMatchers::Matchers::HaveDirectory.new(
+            name, matcher_name: __method__, **options_hash, &
+          )
         end
 
         # Defines an expectation for a symlink within the directory.
         def symlink(name, **)
-          nested_matchers << RSpec::PathMatchers::Matchers::HaveSymlink.new(name, **)
+          nested_matchers << RSpec::PathMatchers::Matchers::HaveSymlink.new(name, matcher_name: __method__, **)
         end
 
         # Defines an expectation that a file does NOT exist within the directory.
         def no_file(name)
-          nested_matchers << RSpec::PathMatchers::Matchers::HaveNoEntry.new(name, type: :file)
+          nested_matchers << RSpec::PathMatchers::Matchers::HaveNoEntry.new(name, entry_type: :file)
         end
 
         # Defines an expectation that a directory does NOT exist within the directory.
         def no_dir(name)
-          nested_matchers << RSpec::PathMatchers::Matchers::HaveNoEntry.new(name, type: :directory)
+          nested_matchers << RSpec::PathMatchers::Matchers::HaveNoEntry.new(name, entry_type: :directory)
         end
 
         # Defines an expectation that a symlink does NOT exist within the directory.
         def no_symlink(name)
-          nested_matchers << RSpec::PathMatchers::Matchers::HaveNoEntry.new(name, type: :symlink)
+          nested_matchers << RSpec::PathMatchers::Matchers::HaveNoEntry.new(name, entry_type: :symlink)
         end
       end
     end

--- a/lib/rspec/path_matchers/matchers/have_directory.rb
+++ b/lib/rspec/path_matchers/matchers/have_directory.rb
@@ -19,6 +19,8 @@ module RSpec
           RSpec::PathMatchers::Options::Owner
         ].freeze
 
+        def entry_type = :directory
+
         attr_reader :nested_matchers, :exact
 
         # Initializes the matcher with the directory name and options
@@ -75,7 +77,6 @@ module RSpec
 
         def option_definitions = OPTIONS
         def correct_type? = File.directory?(path)
-        def matcher_name = 'have_dir'
 
         protected
 
@@ -106,7 +107,7 @@ module RSpec
         def check_for_unexpected_entries
           positively_declared_entries = nested_matchers.reject do |m|
             m.is_a?(RSpec::PathMatchers::Matchers::HaveNoEntry)
-          end.map(&:name)
+          end.map(&:entry_name)
 
           actual_entries = Dir.children(path)
           unexpected_entries = actual_entries - positively_declared_entries

--- a/lib/rspec/path_matchers/matchers/have_file.rb
+++ b/lib/rspec/path_matchers/matchers/have_file.rb
@@ -21,11 +21,11 @@ module RSpec
           RSpec::PathMatchers::Options::YamlContent
         ].freeze
 
+        def entry_type = :file
+
         def option_definitions = OPTIONS
 
         def correct_type? = File.file?(path)
-
-        def matcher_name = 'have_file'
 
         protected
 

--- a/lib/rspec/path_matchers/matchers/have_no_entry.rb
+++ b/lib/rspec/path_matchers/matchers/have_no_entry.rb
@@ -4,16 +4,22 @@
 module RSpec
   module PathMatchers
     module Matchers
-      # Asserts that a directory entry of a specific type does NOT exist.
+      # Asserts that a directory entry of a specific entry_type does NOT exist.
       # This is a simple, internal matcher-like object.
       #
       # @api private
       class HaveNoEntry
-        attr_reader :name
+        attr_reader :name, :matcher_name, :entry_type
 
-        def initialize(name, type:)
+        # Initializes the matcher with the entry name and type
+        #
+        # @param name [String] The name of the entry to check
+        #
+        # @param entry_type [Symbol] The type of the entry (:file, :directory, or :symlink)
+        #
+        def initialize(name, entry_type:)
           @name = name
-          @type = type
+          @entry_type = entry_type
           @base_path = nil
           @path = nil
         end
@@ -23,7 +29,7 @@ module RSpec
           @base_path = base_path
           @path = File.join(base_path, @name)
 
-          case @type
+          case entry_type
           when :file then !File.file?(@path)
           when :directory then !File.directory?(@path)
           else !File.symlink?(@path)
@@ -32,12 +38,12 @@ module RSpec
 
         # The failure message if `execute_match` returns `false`.
         def failure_message
-          "expected #{@type} '#{@name}' not to be found at '#{@base_path}', but it exists"
+          "expected #{entry_type} '#{@name}' not to be found at '#{@base_path}', but it exists"
         end
 
         # Provide a description for the `have_dir` block's output.
         def description
-          "not have #{@type} #{@name.inspect}"
+          "not have #{entry_type} #{@name.inspect}"
         end
 
         # Provide a stub for this method, which is called by HaveDirectory

--- a/lib/rspec/path_matchers/matchers/have_symlink.rb
+++ b/lib/rspec/path_matchers/matchers/have_symlink.rb
@@ -19,11 +19,11 @@ module RSpec
           RSpec::PathMatchers::Options::SymlinkTargetType
         ].freeze
 
+        def entry_type = :symlink
+
         def option_definitions = OPTIONS
 
         def correct_type? = File.symlink?(path)
-
-        def matcher_name = 'have_symlink'
 
         protected
 

--- a/spec/rspec/path_matchers/be_dir_spec.rb
+++ b/spec/rspec/path_matchers/be_dir_spec.rb
@@ -1,0 +1,1159 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe 'the be_dir matcher' do
+  let(:now) { Time.new(1967, 3, 15, 0, 16, 0, '-0700') }
+
+  around(:each) do |example|
+    Dir.mktmpdir do |tmpdir|
+      @tmpdir = tmpdir
+      example.run
+    end
+  end
+
+  let(:tmpdir) { @tmpdir }
+  let(:dir_name) { 'dir' }
+  let(:path) { File.join(tmpdir, dir_name) }
+
+  let(:expectation_not_met_error) { RSpec::Expectations::ExpectationNotMetError }
+
+  before do
+    Dir.mkdir(path)
+  end
+
+  describe 'checking existance' do
+    subject { expect(path).to be_dir }
+
+    context 'when the entry at the given path is a regular file' do
+      before do
+        FileUtils.rm_rf(path)
+        FileUtils.touch(path)
+      end
+
+      it 'should fail' do
+        expected_message = /expected it to be a directory/
+        expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+      end
+    end
+
+    context 'when the entry at the given path does not exist' do
+      before do
+        FileUtils.rm_rf(path)
+      end
+      it 'should fail' do
+        expected_message = /expected it to exist/
+        expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+      end
+    end
+
+    context 'when the entry at the given path is not a directory' do
+      before do
+        FileUtils.rm_rf(path)
+        File.write(path, 'not a directory')
+      end
+
+      it 'should fail' do
+        expected_message = /expected it to be a directory/
+        expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+      end
+    end
+
+    context 'when the entry at the given path is a symlink to a directory' do
+      before do
+        FileUtils.rm_rf(path)
+        Dir.mkdir(File.join(tmpdir, 'target_dir'))
+        File.symlink('target_dir', path)
+      end
+
+      it 'should not fail' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the entry at the given path is a symlink to a regular file' do
+      before do
+        FileUtils.rm_rf(path)
+        file_path = File.join(tmpdir, 'target_file.txt')
+        File.write(file_path, 'regular file')
+        File.symlink(file_path, path)
+      end
+
+      it 'should fail' do
+        expected_message = /expected it to be a directory/
+        expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+      end
+    end
+
+    context 'when the entry at the given path is a dangling symlink' do
+      before do
+        FileUtils.rm_rf(path)
+        target_path = File.join(tmpdir, 'target.txt')
+        File.symlink(target_path, File.join(tmpdir, 'link.txt'))
+      end
+
+      it 'should fail' do
+        expected_message = /expected it to exist/
+        expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+      end
+    end
+  end
+
+  describe 'not_to be_dir' do
+    context 'with no options and no specification block' do
+      subject { expect(path).not_to be_dir }
+
+      context 'when the entry at the given path does not exist' do
+        before { FileUtils.rm_rf(path) }
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the entry at the given path is a directory' do
+        # The outer `before` specification block already creates the directory `path`
+        it 'should fail' do
+          expected_message = /expected it not to be a directory/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+
+      context 'when the entry at the given path is a file' do
+        before do
+          FileUtils.rm_rf(path)
+          File.write(path, 'I am a file')
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the entry at the given path is a symlink to a directory' do
+        let(:target_dir) { File.join(tmpdir, 'target_dir') }
+
+        before do
+          FileUtils.rm_rf(path)
+          Dir.mkdir(target_dir)
+          File.symlink(target_dir, path)
+        end
+
+        it 'should fail' do
+          expected_message = /expected it not to be a directory/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+
+      context 'when the entry at the given path is a symlink to a file' do
+        let(:target_file) { File.join(tmpdir, 'target_file.txt') }
+
+        before do
+          FileUtils.rm_rf(path)
+          File.write(target_file, 'I am a file')
+          File.symlink(target_file, path)
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the entry at the given path is a dangling symlink' do
+        let(:dangling_target) { File.join(tmpdir, 'non_existent_target') }
+
+        before do
+          FileUtils.rm_rf(path)
+          File.symlink(dangling_target, path)
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+    end
+
+    context 'with a specification block' do
+      subject do
+        expect(path).not_to(be_dir { file('asdf') })
+      end
+
+      it 'should raise an ArgumentError' do
+        expected_message = 'The matcher `not_to be_dir(...)` cannot be given a specification block'
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'with any options' do
+      subject { expect(path).not_to be_dir(mode: '0755') }
+
+      it 'should raise an ArgumentError' do
+        expected_message = 'The matcher `not_to be_dir(...)` cannot be given options'
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+  end
+
+  context 'when given invalid options' do
+    subject { expect(path).to be_dir(**options) }
+
+    context 'with an invalid option' do
+      let(:options) { { invalid_option: true } }
+      it 'should raise an ArgumentError' do
+        expected_message = /unknown keyword: :invalid_option/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'with more than one invalid option' do
+      let(:options) { { invalid_option: true, another_invalid: false } }
+      it 'should raise an ArgumentError listing all invalid options' do
+        expected_message = /unknown keywords: :invalid_option, :another_invalid/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+  end
+
+  describe 'the mode: option' do
+    subject { expect(path).to be_dir(mode: expected_mode) }
+
+    context 'when the expected value is not valid' do
+      let(:expected_mode) { 123 }
+      it 'should raise an ArgumentError' do
+        expected_message = /expected `mode:` to be a Matcher or String, but was 123/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when given a String' do
+      let(:expected_mode) { '0644' }
+
+      context 'when the expected mode matches the actual mode' do
+        let(:actual_mode) { expected_mode }
+        it 'should not fail' do
+          FileUtils.chmod(expected_mode.to_i(8), path)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected mode does not match the actual mode' do
+        let(:actual_mode) { '0755' }
+        it 'should fail' do
+          FileUtils.chmod(actual_mode.to_i(8), path)
+          expected_message = /expected mode to be "0644", but was "0755"/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when given a matcher' do
+      let(:expected_mode) { match(/^07..$/) }
+
+      context 'when the expected mode matches the actual mode' do
+        let(:actual_mode) { '0755' }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          FileUtils.chmod(actual_mode.to_i(8), path)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected mode does not match the actual mode' do
+        let(:actual_mode) { '0600' }
+        it 'should fail' do
+          FileUtils.touch(path)
+          FileUtils.chmod(actual_mode.to_i(8), path)
+          expected_message = Regexp.escape('expected mode to match /^07..$/, but was "0600"')
+          expect { subject }.to raise_error(expectation_not_met_error, /#{expected_message}/)
+        end
+      end
+    end
+  end
+
+  describe 'the owner: option' do
+    subject { expect(path).to be_dir(owner: expected_owner) }
+
+    def mock_owner(path, actual_owner)
+      uid = 9999
+      allow(File).to receive(:stat).with(path).and_return(double(uid: uid))
+      allow(Etc).to receive(:getpwuid).and_return(double(name: actual_owner))
+    end
+
+    context 'when the expected owner is not valid' do
+      let(:expected_owner) { 123 }
+
+      it 'should raise an ArgumentError' do
+        expected_message = /expected `owner:` to be a Matcher or String, but was 123/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when the platform does not support owner expectations' do
+      let(:expected_owner) { 'testuser' }
+
+      it 'should give a warning and not check the owner' do
+        allow(Etc).to receive(:respond_to?).and_call_original
+        allow(Etc).to receive(:respond_to?).with(:getpwuid).and_return(false)
+
+        FileUtils.touch(path)
+
+        expect(RSpec.configuration.reporter).to receive(:message).with(
+          'WARNING: owner expectations are not supported on this platform and will be skipped.'
+        )
+
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when given a String' do
+      let(:expected_owner) { 'testuser' }
+
+      context 'when the expected owner matches the actual owner' do
+        let(:actual_owner) { expected_owner }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_owner(path, actual_owner)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected owner does not match the actual owner' do
+        let(:actual_owner) { 'otheruser' }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_owner(path, actual_owner)
+          expected_message = /expected owner to be "testuser", but was "otheruser"/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when given a matcher' do
+      let(:expected_owner) { eq 'testuser' }
+
+      context 'when the expected owner matches the actual owner' do
+        let(:actual_owner) { 'testuser' }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_owner(path, actual_owner)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected owner does not match the actual owner' do
+        let(:actual_owner) { 'otheruser' }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_owner(path, actual_owner)
+          expected_message = /expected owner to eq "testuser", but was "otheruser"/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+  end
+
+  describe 'the group: option' do
+    subject { expect(path).to be_dir(group: expected_group) }
+
+    # Etc.getgrgid(File.stat(path).gid).name
+    def mock_group(path, name)
+      gid = 9999
+      allow(File).to receive(:stat).with(path).and_return(double(gid:))
+      allow(Etc).to receive(:getgrgid).with(gid).and_return(double(name:))
+    end
+
+    context 'when given an invalid group value' do
+      let(:expected_group) { 123 }
+      it 'should raise an ArgumentError' do
+        expected_message = /expected `group:` to be a Matcher or String, but was 123/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when the platform does not support group expectations' do
+      let(:expected_group) { 'testgroup' }
+
+      it 'should give a warning and not check the group' do
+        allow(Etc).to receive(:respond_to?).and_call_original
+        allow(Etc).to receive(:respond_to?).with(:getgrgid).and_return(false)
+
+        FileUtils.touch(path)
+
+        expect(RSpec.configuration.reporter).to receive(:message).with(
+          'WARNING: group expectations are not supported on this platform and will be skipped.'
+        )
+
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when given a String' do
+      let(:expected_group) { 'testgroup' }
+
+      context 'when the expected group matches the actual group' do
+        let(:actual_group) { expected_group }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_group(path, actual_group)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected group does not match the actual group' do
+        let(:actual_group) { 'othergroup' }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_group(path, actual_group)
+          expected_message = /expected group to be "testgroup", but was "othergroup"/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when given a matcher' do
+      let(:expected_group) { eq 'testgroup' }
+
+      context 'when the expected group matches the actual group' do
+        let(:actual_group) { 'testgroup' }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_group(path, actual_group)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected group does not match the actual group' do
+        let(:actual_group) { 'othergroup' }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_group(path, actual_group)
+          expected_message = /expected group to eq "testgroup", but was "othergroup"/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+  end
+
+  describe 'the atime: option' do
+    subject { expect(path).to be_dir(atime: expected_atime) }
+
+    def mock_atime(path, actual_atime)
+      allow(File).to receive(:stat).with(path).and_return(double(atime: actual_atime))
+    end
+
+    context 'when the expected atime is not valid' do
+      let(:expected_atime) { 'invalid' }
+
+      it 'should raise an ArgumentError' do
+        FileUtils.touch(path)
+        expected_message = /expected `atime:` to be a Matcher, Time, or DateTime, but was "invalid"/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when expected atime is a Time' do
+      let(:expected_atime) { now }
+
+      context 'when the expected atime matches the actual atime' do
+        let(:actual_atime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_atime(path, expected_atime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected atime does not match the actual atime' do
+        let(:actual_atime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_atime(path, actual_atime)
+          expected_message = /expected atime to be #{expected_atime.inspect}, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when the expected atime is a DateTime' do
+      let(:expected_atime) { now.to_datetime }
+
+      context 'when the expected atime matches the actual atime' do
+        let(:actual_atime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_atime(path, actual_atime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected atime does not match the actual atime' do
+        let(:actual_atime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_atime(path, actual_atime)
+          expected_message = /expected atime to be 1967-03-15 00:16:00 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when the expected atime is a matcher' do
+      let(:expected_atime) { be_within(10).of(now) }
+
+      context 'when the expected atime matches the actual atime' do
+        let(:actual_atime) { now - 5 }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_atime(path, actual_atime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected atime does not match the actual atime' do
+        let(:actual_atime) { now - 20 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_atime(path, actual_atime)
+          expected_message = /expected atime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+  end
+
+  describe 'the birthtime: option' do
+    subject { expect(path).to be_dir(birthtime: expected_birthtime) }
+
+    def mock_birthtime(path, actual_birthtime)
+      allow(File).to receive(:stat).with(path).and_return(double(birthtime: actual_birthtime))
+    end
+
+    context 'for a path that does not support birthtime' do
+      let(:expected_birthtime) { now }
+
+      before do
+        allow_any_instance_of(File::Stat).to receive(:birthtime).and_raise(NotImplementedError)
+      end
+
+      it 'should give a warning and skip the birthtime check' do
+        expected_message = "WARNING: birthtime expectations are not supported for #{path} and will be skipped"
+        expect(RSpec.configuration.reporter).to receive(:message).with(expected_message)
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the expected birthtime is not valid' do
+      let(:expected_birthtime) { 'invalid' }
+
+      it 'should raise an ArgumentError' do
+        FileUtils.touch(path)
+        expected_message = /expected `birthtime:` to be a Matcher, Time, or DateTime, but was "invalid"/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when expected birthtime is a Time' do
+      let(:expected_birthtime) { now }
+
+      context 'when the expected birthtime matches the actual birthtime' do
+        let(:actual_birthtime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_birthtime(path, expected_birthtime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected birthtime does not match the actual birthtime' do
+        let(:actual_birthtime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_birthtime(path, actual_birthtime)
+          expected_message = /expected birthtime to be #{expected_birthtime.inspect}, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when the expected birthtime is a DateTime' do
+      let(:expected_birthtime) { now.to_datetime }
+
+      context 'when the expected birthtime matches the actual birthtime' do
+        let(:actual_birthtime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_birthtime(path, actual_birthtime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected birthtime does not match the actual birthtime' do
+        let(:actual_birthtime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_birthtime(path, actual_birthtime)
+          expected_messsage = /expected birthtime to be 1967-03-15 00:16:00 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_messsage)
+        end
+      end
+    end
+
+    context 'when the expected birthtime is a matcher' do
+      let(:expected_birthtime) { be_within(10).of(now) }
+
+      context 'when the expected birthtime matches the actual birthtime' do
+        let(:actual_birthtime) { now - 5 }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_birthtime(path, actual_birthtime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected birthtime does not match the actual birthtime' do
+        let(:actual_birthtime) { now - 20 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_birthtime(path, actual_birthtime)
+          expected_message = /expected birthtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+  end
+
+  describe 'the ctime: option' do
+    subject { expect(path).to be_dir(ctime: expected_ctime) }
+
+    def mock_ctime(path, actual_ctime)
+      allow(File).to receive(:stat).with(path).and_return(double(ctime: actual_ctime))
+    end
+
+    context 'when the expected ctime is not valid' do
+      let(:expected_ctime) { 'invalid' }
+
+      it 'should raise an ArgumentError' do
+        FileUtils.touch(path)
+        expected_message = /expected `ctime:` to be a Matcher, Time, or DateTime, but was "invalid"/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when expected ctime is a Time' do
+      let(:expected_ctime) { now }
+
+      context 'when the expected ctime matches the actual ctime' do
+        let(:actual_ctime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_ctime(path, expected_ctime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected ctime does not match the actual ctime' do
+        let(:actual_ctime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_ctime(path, actual_ctime)
+          expected_message = /expected ctime to be #{expected_ctime.inspect}, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when the expected ctime is a DateTime' do
+      let(:expected_ctime) { now.to_datetime }
+
+      context 'when the expected ctime matches the actual ctime' do
+        let(:actual_ctime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_ctime(path, actual_ctime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected ctime does not match the actual ctime' do
+        let(:actual_ctime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_ctime(path, actual_ctime)
+          expected_message = /expected ctime to be 1967-03-15 00:16:00 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when the expected ctime is a matcher' do
+      let(:expected_ctime) { be_within(10).of(now) }
+
+      context 'when the expected ctime matches the actual ctime' do
+        let(:actual_ctime) { now - 5 }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_ctime(path, actual_ctime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected ctime does not match the actual ctime' do
+        let(:actual_ctime) { now - 20 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_ctime(path, actual_ctime)
+          expected_message = /expected ctime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+  end
+
+  describe 'the mtime: option' do
+    subject { expect(path).to be_dir(mtime: expected_mtime) }
+
+    def mock_mtime(path, actual_mtime)
+      allow(File).to receive(:stat).with(path).and_return(double(mtime: actual_mtime))
+    end
+
+    context 'when given an invalid mtime value' do
+      let(:expected_mtime) { 'invalid' }
+
+      it 'should raise an ArgumentError' do
+        FileUtils.touch(path)
+        expected_message = /expected `mtime:` to be a Matcher, Time, or DateTime, but was "invalid"/
+        expect { subject }.to raise_error(ArgumentError, expected_message)
+      end
+    end
+
+    context 'when given a Time' do
+      let(:expected_mtime) { now }
+
+      context 'when the expected mtime matches the actual mtime' do
+        let(:actual_mtime) { expected_mtime }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_mtime(path, actual_mtime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected mtime does not match the actual mtime' do
+        let(:actual_mtime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_mtime(path, actual_mtime)
+
+          expected_message = /expected mtime to be #{expected_mtime.inspect}, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when given a DateTime' do
+      let(:expected_mtime) { now.to_datetime }
+
+      context 'when the expected mtime matches the actual mtime' do
+        let(:actual_mtime) { now }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_mtime(path, actual_mtime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected mtime does not match the actual mtime' do
+        let(:actual_mtime) { now + 10 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_mtime(path, actual_mtime)
+          expected_message = /expected mtime to be 1967-03-15 00:16:00 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when given a matcher' do
+      let(:expected_mtime) { be_within(10).of(now) }
+
+      context 'when the expected mtime matches the actual mtime' do
+        let(:actual_mtime) { now - 5 }
+
+        it 'should not fail' do
+          FileUtils.touch(path)
+          mock_mtime(path, actual_mtime)
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the expected mtime does not match the actual mtime' do
+        let(:actual_mtime) { now - 20 }
+
+        it 'should fail' do
+          FileUtils.touch(path)
+          mock_mtime(path, actual_mtime)
+          expected_message = /expected mtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when given a specification block' do
+      context 'with an empty specification block' do
+        subject do
+          expect(path).to(
+            be_dir do
+              # No expectations in the block
+            end
+          )
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'with a specification block checking for a file' do
+        let(:subject) do
+          expect(path).to(
+            be_dir do
+              file('file.json', json_content: true)
+            end
+          )
+        end
+
+        context 'when the specification block expectations are met' do
+          before do
+            File.write(File.join(path, 'file.json'), '{"key": "value"}')
+          end
+
+          it 'should not fail' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'when the specification block expectations are not met' do
+          before do
+            File.write(File.join(path, 'file.json'), 'not a json file')
+          end
+
+          it 'should fail' do
+            expected_message = /expected valid JSON content, but got error: /
+            expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          end
+        end
+      end
+
+      context 'with a specification specification block checking for a directory' do
+        let(:subject) do
+          expect(path).to(
+            be_dir do
+              dir('nested_dir')
+            end
+          )
+        end
+
+        context 'when the specification block expectations are met' do
+          before do
+            nested_path = File.join(path, 'nested_dir')
+            Dir.mkdir(nested_path)
+          end
+
+          it 'should not fail' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'when the specification block expectations are not met' do
+          it 'should fail' do
+            expected_message = /expected it to exist/
+            expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          end
+        end
+      end
+
+      context 'with a specification block checking for a symlink' do
+        let(:subject) do
+          expect(path).to(
+            be_dir do
+              symlink('nested_symlink', target: 'expected_target')
+            end
+          )
+        end
+
+        context 'when the specification block expectations are met' do
+          before do
+            File.symlink('expected_target', File.join(path, 'nested_symlink'))
+          end
+
+          it 'should not fail' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'when the specification block expectations are not met' do
+          it 'should fail' do
+            expected_message = /expected it to exist/
+            expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          end
+        end
+      end
+
+      context 'with a specification block checking for multiple files' do
+        let(:subject) do
+          expect(path).to(
+            be_dir do
+              file('file1.txt', content: 'content1')
+              file('file2.txt', content: 'content2')
+            end
+          )
+        end
+
+        context 'when the specification block expectations are met' do
+          before do
+            File.write(File.join(path, 'file1.txt'), 'content1')
+            File.write(File.join(path, 'file2.txt'), 'content2')
+          end
+
+          it 'should not fail' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'when the specification block expectations are not met' do
+          before do
+            File.write(File.join(path, 'file1.txt'), 'wrong content')
+          end
+
+          it 'should fail' do
+            expected_message = /expected it to exist/
+            expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          end
+        end
+      end
+
+      context 'with a specification block checking for a directory with another specification block' do
+        let(:subject) do
+          expect(path).to(
+            be_dir do
+              dir('nested_dir') do
+                file('deeply_nested_file.txt', content: 'content')
+              end
+            end
+          )
+        end
+
+        context 'when the specification block expectations are met' do
+          before do
+            nested_path = File.join(path, 'nested_dir')
+            Dir.mkdir(nested_path)
+            File.write(File.join(nested_path, 'deeply_nested_file.txt'), 'content')
+          end
+
+          it 'should not fail' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'when the specification block expectations are not met' do
+          before do
+            nested_path = File.join(path, 'nested_dir')
+            Dir.mkdir(nested_path)
+            File.write(File.join(nested_path, 'deeply_nested_file.txt'), 'unexpected content')
+          end
+
+          it 'should fail' do
+            expected_message = /expected content to be "content"/
+            expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          end
+        end
+      end
+    end
+  end
+
+  context 'with negative assertions in the specification block' do
+    describe 'the no_file method' do
+      subject do
+        expect(path).to(
+          be_dir do
+            no_file('entry.txt')
+          end
+        )
+      end
+
+      context 'when the file does not exist' do
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when an entry with the same name exists but is a directory' do
+        before do
+          Dir.mkdir(File.join(path, 'entry.txt'))
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the file exists' do
+        before do
+          File.write(File.join(path, 'entry.txt'), 'content')
+        end
+
+        it 'should fail' do
+          expected_message = /expected file 'entry\.txt' not to be found at '.*', but it exists/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    describe 'the no_dir method' do
+      subject do
+        expect(path).to(
+          be_dir do
+            no_dir('subdir')
+          end
+        )
+      end
+
+      context 'when the directory does not exist' do
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when an entry with the same name exists but is a file' do
+        before do
+          File.write(File.join(path, 'subdir'), 'content')
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the directory exists' do
+        before do
+          Dir.mkdir(File.join(path, 'subdir'))
+        end
+
+        it 'should fail' do
+          expected_message = /expected directory 'subdir' not to be found at '.*', but it exists/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    describe 'the no_symlink method' do
+      subject do
+        expect(path).to(
+          be_dir do
+            no_symlink('a_link')
+          end
+        )
+      end
+
+      context 'when the symlink does not exist' do
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when an entry with the same name exists but is a file' do
+        before do
+          File.write(File.join(path, 'a_link'), 'content')
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when the symlink exists' do
+        before do
+          File.symlink('a_target', File.join(path, 'a_link'))
+        end
+
+        it 'should fail' do
+          expected_message = /expected symlink 'a_link' not to be found at '.*', but it exists/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+
+    context 'when mixing positive and negative assertions' do
+      subject do
+        expect(path).to(
+          be_dir do
+            file 'good_file.txt'
+            no_file 'bad_file.txt'
+          end
+        )
+      end
+
+      context 'when all assertions are met' do
+        before do
+          File.write(File.join(path, 'good_file.txt'), 'content')
+        end
+
+        it 'should not fail' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when a positive assertion fails' do
+        # 'good_file.txt' is not created
+        it 'should fail' do
+          expected_message = /expected it to exist/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+
+      context 'when a negative assertion fails' do
+        before do
+          File.write(File.join(path, 'good_file.txt'), 'content')
+          File.write(File.join(path, 'bad_file.txt'), 'i should not be here')
+        end
+
+        it 'should fail' do
+          expected_message = /expected file 'bad_file\.txt' not to be found at '.*', but it exists/
+          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/path_matchers/description/be_dir_spec.rb
+++ b/spec/rspec/path_matchers/description/be_dir_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-RSpec.describe 'have_dir.description' do
+RSpec.describe 'be_dir.description' do
   subject(:description) { matcher.description }
 
   context 'with no options or block' do
-    let(:matcher) { have_dir('my_dir') }
-    it { is_expected.to eq('have directory "my_dir"') }
+    let(:matcher) { be_dir }
+    it { is_expected.to eq('be a directory') }
   end
 
   context 'with options' do
-    let(:matcher) { have_dir('my_dir', mode: '0755', owner: 'dev') }
-    it { is_expected.to eq('have directory "my_dir" with mode "0755" and owner "dev"') }
+    let(:matcher) { be_dir(mode: '0755', owner: 'dev') }
+    it { is_expected.to eq('be a directory with mode "0755" and owner "dev"') }
   end
 
   context 'with the exact option' do
-    let(:matcher) { have_dir('my_dir', exact: true) }
-    it { is_expected.to eq('have directory "my_dir" exactly') }
+    let(:matcher) { be_dir(exact: true) }
+    it { is_expected.to eq('be a directory exactly') }
   end
 
   context 'with one nested matcher' do
     let(:matcher) do
-      have_dir('my_dir') do
+      be_dir do
         file 'a.txt', content: 'hello'
       end
     end
     let(:expected_description) do
       <<~DESC.chomp
-        have directory "my_dir" containing:
+        be a directory containing:
           - have file "a.txt" with content "hello"
       DESC
     end
@@ -35,14 +35,14 @@ RSpec.describe 'have_dir.description' do
 
   context 'with two nested matchers' do
     let(:matcher) do
-      have_dir('my_dir') do
+      be_dir do
         file 'a.txt'
         dir 'subdir'
       end
     end
     let(:expected_description) do
       <<~DESC.chomp
-        have directory "my_dir" containing:
+        be a directory containing:
           - have file "a.txt"
           - have directory "subdir"
       DESC
@@ -52,7 +52,7 @@ RSpec.describe 'have_dir.description' do
 
   context 'with a deeply nested structure' do
     let(:matcher) do
-      have_dir('app', owner: 'dev') do
+      be_dir(owner: 'dev') do
         dir 'models' do
           file 'user.rb', size: be > 100
         end
@@ -61,7 +61,7 @@ RSpec.describe 'have_dir.description' do
     end
     let(:expected_description) do
       <<~DESC.chomp
-        have directory "app" with owner "dev" containing:
+        be a directory with owner "dev" containing:
           - have directory "models" containing:
             - have file "user.rb" with size be > 100
           - have file "config.ru"

--- a/spec/rspec/path_matchers/description/have_no_entry_spec.rb
+++ b/spec/rspec/path_matchers/description/have_no_entry_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe RSpec::PathMatchers::Matchers::HaveNoEntry do
-  let(:matcher) { described_class.new(name, type:) }
+  let(:matcher) { described_class.new(name, entry_type:) }
 
   describe '#description' do
     subject { matcher.description }
 
     context 'for file type' do
       let(:name) { 'file.txt' }
-      let(:type) { 'file' }
+      let(:entry_type) { 'file' }
       it { is_expected.to eq('not have file "file.txt"') }
     end
     context 'for file directory' do
       let(:name) { 'dir' }
-      let(:type) { 'directory' }
+      let(:entry_type) { 'directory' }
       it { is_expected.to eq('not have directory "dir"') }
     end
     context 'for file symlink' do
       let(:name) { 'symlink.txt' }
-      let(:type) { 'symlink' }
+      let(:entry_type) { 'symlink' }
       it { is_expected.to eq('not have symlink "symlink.txt"') }
     end
   end

--- a/spec/rspec/path_matchers/matchers/base_spec.rb
+++ b/spec/rspec/path_matchers/matchers/base_spec.rb
@@ -1,35 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe RSpec::PathMatchers::Matchers::Base do
-  context 'when subclassed to create a matcher' do
-    let(:matcher) do
-      Class.new(described_class) do
-        def option_definitions = []
-      end.new('test_file')
+  context 'when not subclassed' do
+    let(:name) { double('name') }
+    let(:matcher_name) { double('matcher_name') }
+
+    let(:base_matcher) { described_class.new(name, matcher_name:) }
+
+    describe '.correct_type?' do
+      subject { base_matcher.send(:correct_type?) }
+      it_behaves_like 'an abstract method'
     end
 
-    describe '#matches?' do
-      context 'when not overridden in the subclass' do
-        it 'raises NotImplementedError' do
-          expect { matcher.matches?('/tmp') }.to raise_error(NotImplementedError)
-        end
-      end
+    describe '.entry_type' do
+      subject { base_matcher.send(:entry_type) }
+      it_behaves_like 'an abstract method'
     end
 
-    describe '#correct_type?' do
-      context 'when not overridden in the subclass' do
-        it 'raises NotImplementedError' do
-          expect { matcher.correct_type? }.to raise_error(NotImplementedError)
-        end
-      end
-    end
-
-    describe '#matcher_name' do
-      context 'when not overridden in the subclass' do
-        it 'raises NotImplementedError' do
-          expect { matcher.matcher_name }.to raise_error(NotImplementedError)
-        end
-      end
+    describe '.validate_existance' do
+      let(:failure_messages) { double('failure_messages') }
+      subject { base_matcher.send(:validate_existance, failure_messages) }
+      it_behaves_like 'an abstract method'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,16 @@ RSpec.shared_examples 'an abstract class method' do
   end
 end
 
+RSpec.shared_examples 'an abstract method' do
+  it 'raises NotImplementedError' do
+    expect { subject }.to raise_error(NotImplementedError) do |e|
+      class_name = described_class.to_s.split('::').last
+      method_name = e.backtrace_locations.first.label.split('::').last.split('#').last
+      expect(e.message).to eq("Subclasses must implement #{class_name}##{method_name}")
+    end
+  end
+end
+
 require 'simplecov-rspec'
 
 SimpleCov.enable_coverage :branch


### PR DESCRIPTION
The be_dir matcher allows you to say:

`expect(project_dir).to be_dir`

which is equivalent to saying:

`expect(project_dir).to have_dir('.')`

but it looks a lot nicer.
 