### PR TITLE
Update README to include CHANGELOG badge

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--hide-void-return
+--markup-provider=redcarpet
+--markup markdown
+--readme README.md
+- CHANGELOG.md
+- LICENSE.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Unreleased]
-
 ## [0.2.0](https://github.com/main-branch/rspec-path_matchers/compare/v0.1.1...v0.2.0) (2025-06-30)
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gem
 Version](https://img.shields.io/gem/v/rspec-path_matchers.svg)](https://rubygems.org/gems/rspec-path_matchers)
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/rspec-path_matchers/)
+[![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/ruby_git/file/CHANGELOG.md)
 [![Continuous Integration](https://github.com/main-branch/rspec-path_matchers/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/main-branch/rspec-path_matchers/actions/workflows/continuous_integration.yml)
 [![MIT
 License](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Add a badge to the README for the CHANGELOG, enhancing visibility and accessibility of the change log for users.

In order to do this, I had to add the CHANGELOG to the generated Yard documentation.