### PR TITLE
Make error messages consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ expect('config').to(
 ```text
 'config' was not as expected:
   - database.xml
-      expected owner to be "db_user", but was "root"
-      expected mode to be "0600", but was "0644"
+      expected owner to be "db_user", but it was "root"
+      expected mode to be "0600", but it was "0644"
 ```
 
 ## Development

--- a/lib/rspec/path_matchers/matchers/directory_matcher.rb
+++ b/lib/rspec/path_matchers/matchers/directory_matcher.rb
@@ -164,7 +164,7 @@ module RSpec
         end
 
         def build_unexpected_entries_message(unexpected_entries)
-          "contained unexpected entries #{unexpected_entries.sort.inspect}"
+          "expected no other entries, but found #{unexpected_entries.sort.inspect}"
         end
       end
     end

--- a/lib/rspec/path_matchers/options/base.rb
+++ b/lib/rspec/path_matchers/options/base.rb
@@ -102,7 +102,7 @@ module RSpec
 
           types = ['Matcher', *valid_expected_types.map(&:name)].to_sentence(conjunction: 'or')
 
-          errors << "expected `#{key}:` to be a #{types}, but was #{expected.inspect}"
+          errors << "expected `#{key}:` to be a #{types}, but it was #{expected.inspect}"
         end
 
         protected
@@ -189,36 +189,6 @@ module RSpec
         #
         private_class_method def self.literal_match?(actual, expected) = actual == expected
 
-        # Generates a failure message for a literal match failure
-        #
-        # This is used when the actual value does not match the expected value.
-        # It provides a clear message indicating what was expected and what was
-        # actually found.
-        #
-        # Option subclasses should override this method to provide custom failure
-        # messages for specific types of options.
-        #
-        # @example generate a failure message for a literal match failure
-        #  def self.literal_failure_message(actual, expected)
-        #    if expected.is_a?(Regexp)
-        #      "expected #{key} to match #{expected.inspect}, but was #{actual.inspect}"
-        #    else
-        #      "expected #{key} to be #{expected.inspect}, but was #{actual.inspect}"
-        #    end
-        #  end
-        #
-        # @param actual [Object] the actual value fetched from the file system
-        #
-        # @param expected [Object] the expected literal value to match against
-        #
-        # @return [String] the failure message
-        #
-        # @api protected
-        #
-        private_class_method def self.literal_failure_message(actual, expected)
-          "expected #{key} to be #{expected.inspect}, but was #{actual.inspect}"
-        end
-
         # Add to `failures` if actual value matches the normalized expected value
         #
         # This is called when expected is not an RSpec matcher.
@@ -242,12 +212,41 @@ module RSpec
 
           return if literal_match?(actual, expected)
 
-          message = literal_failure_message(actual, expected)
-          add_failure(message, failures)
+          add_failure(literal_failure_message(actual, expected), failures)
         end
 
         private_class_method def self.add_failure(message, failures)
           failures << RSpec::PathMatchers::Failure.new('.', message)
+        end
+
+        # Generates a failure message for a literal match failure
+        #
+        # This is used when the actual value does not match the expected value.
+        # It provides a clear message indicating what was expected and what was
+        # actually found.
+        #
+        # Option subclasses should override this method to provide custom failure
+        # messages for specific types of options.
+        #
+        # @example generate a failure message for a literal match failure
+        #  def self.literal_failure_message(actual, expected)
+        #    if expected.is_a?(Regexp)
+        #      "expected #{key} to match #{expected.inspect}, but it was #{actual.inspect}"
+        #    else
+        #      "expected #{key} to be #{expected.inspect}, but it was #{actual.inspect}"
+        #    end
+        #  end
+        #
+        # @param actual [Object] the actual value fetched from the file system
+        #
+        # @param expected [Object] the expected literal value to match against
+        #
+        # @return [String] the failure message
+        #
+        # @api protected
+        #
+        private_class_method def self.literal_failure_message(actual, expected)
+          "expected #{key} to be #{expected.inspect}, but it was #{actual.inspect}"
         end
 
         # Add to `failures` if actual value matches the normalized expected value
@@ -271,8 +270,28 @@ module RSpec
         private_class_method def self.match_matcher(actual, expected, failures)
           return if expected.matches?(actual)
 
-          message = "expected #{key} to #{expected.description}, but was #{actual.inspect}"
-          add_failure(message, failures)
+          add_failure(matcher_failure_message(actual, expected), failures)
+        end
+
+        # Generates a failure message for a matcher match failure
+        #
+        # This is used when the actual value does not match the expected value.
+        # It provides a clear message indicating what was expected and what was
+        # actually found.
+        #
+        # Option subclasses should override this method to provide custom failure
+        # messages for specific types of options.
+        #
+        # @param actual [Object] the actual value fetched from the file system
+        #
+        # @param expected [Object] the expected literal value to match against
+        #
+        # @return [String] the failure message
+        #
+        # @api protected
+        #
+        private_class_method def self.matcher_failure_message(actual, expected)
+          "expected #{key} to #{expected.description}, but it was #{actual.inspect}"
         end
 
         # Warning message for unsupported expectations

--- a/lib/rspec/path_matchers/options/content.rb
+++ b/lib/rspec/path_matchers/options/content.rb
@@ -11,18 +11,28 @@ module RSpec
         def self.fetch_actual(path, _failures) = File.read(path)
         def self.valid_expected_types = [String, Regexp]
 
+        # Override to provide custom matching logic for regexp literals
         def self.literal_match?(actual, expected)
-          return expected.match?(actual) if expected.is_a?(Regexp)
+          expected.is_a?(Regexp) ? expected.match?(actual) : super
+        end
 
-          super
+        # Handles failures when a matcher is used (e.g., content: include('...'))
+        def self.matcher_failure_message(actual, expected)
+          actual_summary = actual.length > 100 ? 'did not' : "was #{actual.inspect}"
+          "expected content to #{expected.description}, but it #{actual_summary}"
         end
 
         def self.literal_failure_message(actual, expected)
-          if expected.is_a?(Regexp)
-            "expected content to match #{expected.inspect}, but got #{actual.inspect}"
-          else
-            super
-          end
+          verb = expected.is_a?(Regexp) ? 'match' : 'be'
+
+          actual_summary =
+            if actual.length > 100
+              verb == 'match' ? 'did not' : 'was not'
+            else
+              "was #{actual.inspect}"
+            end
+
+          "expected content to #{verb} #{expected.inspect}, but it #{actual_summary}"
         end
       end
     end

--- a/lib/rspec/path_matchers/options/parsed_content_base.rb
+++ b/lib/rspec/path_matchers/options/parsed_content_base.rb
@@ -29,17 +29,16 @@ module RSpec
         # This is the `xxxx_content: true` case. A successful fetch_actual is sufficient
         def self.match_literal(_actual, _expected, _failures); end
 
-        # Compares the parsed content against the given RSpec matcher.
+        # Failure message for when a matcher is used (e.g., `json_content: include(...)`)
         #
         # @param (see RSpec::PathMatchers::Options::Base.match_matcher)
         #
         # @return [void]
         #
-        def self.match_matcher(actual, expected, failures)
-          return if expected.matches?(actual)
+        def self.matcher_failure_message(actual, expected)
+          actual_summary = actual.inspect.length > 100 ? 'it did not' : "was #{actual.inspect}"
 
-          message = "expected #{content_type} content to #{expected.description}"
-          add_failure(message, failures)
+          "expected #{content_type} content to #{expected.description}, but #{actual_summary}"
         end
 
         # Provides a human-readable description for the option

--- a/spec/rspec/path_matchers/be_dir_exact_spec.rb
+++ b/spec/rspec/path_matchers/be_dir_exact_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'the be_dir matcher' do
             expected_message = <<~MESSAGE.chomp
               #{tmpdir} was not as expected:
                 - #{entry_name}
-                    contained unexpected entries ["file1.txt"]
+                    expected no other entries, but found ["file1.txt"]
             MESSAGE
 
             expect { subject }.to raise_error(expectation_not_met_error) do |error|
@@ -195,7 +195,9 @@ RSpec.describe 'the be_dir matcher' do
           it 'should fail with the `no_file` failure message' do
             # This ensures the `no_file` check runs and its failure message is prioritized.
             expected_message = /expected file 'file2.txt' not to be found at '.*', but it exists/
-            expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+            expect { subject }.to raise_error(expectation_not_met_error) do |error|
+              expect(error.message).to match(expected_message)
+            end
           end
         end
 
@@ -266,7 +268,7 @@ RSpec.describe 'the be_dir matcher' do
             expected_message = <<~MESSAGE.chomp
               #{tmpdir} was not as expected:
                 - dir/nested_dir
-                    contained unexpected entries ["unexpected_file1.txt", "unexpected_file2.txt"]
+                    expected no other entries, but found ["unexpected_file1.txt", "unexpected_file2.txt"]
             MESSAGE
             expect { subject }.to raise_error(expectation_not_met_error) do |error|
               expect(error.message).to eq(expected_message)

--- a/spec/rspec/path_matchers/be_dir_spec.rb
+++ b/spec/rspec/path_matchers/be_dir_spec.rb
@@ -197,7 +197,9 @@ RSpec.describe 'the be_dir matcher' do
       let(:options) { { invalid_option: true } }
       it 'should raise an ArgumentError' do
         expected_message = /unknown keyword: :invalid_option/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -205,7 +207,9 @@ RSpec.describe 'the be_dir matcher' do
       let(:options) { { invalid_option: true, another_invalid: false } }
       it 'should raise an ArgumentError listing all invalid options' do
         expected_message = /unknown keywords: :invalid_option, :another_invalid/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
   end
@@ -218,8 +222,10 @@ RSpec.describe 'the be_dir matcher' do
     context 'when the expected value is not valid' do
       let(:expected_mode) { 123 }
       it 'should raise an ArgumentError' do
-        expected_message = /expected `mode:` to be a Matcher or String, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `mode:` to be a Matcher or String, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -238,8 +244,10 @@ RSpec.describe 'the be_dir matcher' do
         let(:actual_mode) { '0755' }
         it 'should fail' do
           FileUtils.chmod(actual_mode.to_i(8), path)
-          expected_message = /expected mode to be "0644", but was "0755"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mode to be "0644", but it was "0755"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -262,8 +270,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           FileUtils.chmod(actual_mode.to_i(8), path)
-          expected_message = Regexp.escape('expected mode to match /^07..$/, but was "0600"')
-          expect { subject }.to raise_error(expectation_not_met_error, /#{expected_message}/)
+          expected_message = Regexp.escape('expected mode to match /^07..$/, but it was "0600"')
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -278,8 +288,10 @@ RSpec.describe 'the be_dir matcher' do
       let(:expected_owner) { 123 }
 
       it 'should raise an ArgumentError' do
-        expected_message = /expected `owner:` to be a Matcher or String, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `owner:` to be a Matcher or String, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -321,8 +333,10 @@ RSpec.describe 'the be_dir matcher' do
           FileUtils.touch(path)
           mock_file_stat(path, uid: 9999)
           mock_user_name(9999, actual_owner)
-          expected_message = /expected owner to be "testuser", but was "otheruser"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected owner to be "testuser", but it was "otheruser"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -348,8 +362,10 @@ RSpec.describe 'the be_dir matcher' do
           FileUtils.touch(path)
           mock_file_stat(path, uid: 9999)
           mock_user_name(9999, actual_owner)
-          expected_message = /expected owner to eq "testuser", but was "otheruser"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected owner to eq "testuser", but it was "otheruser"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -363,8 +379,10 @@ RSpec.describe 'the be_dir matcher' do
     context 'when given an invalid group value' do
       let(:expected_group) { 123 }
       it 'should raise an ArgumentError' do
-        expected_message = /expected `group:` to be a Matcher or String, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `group:` to be a Matcher or String, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -406,8 +424,10 @@ RSpec.describe 'the be_dir matcher' do
           FileUtils.touch(path)
           mock_file_stat(path, gid: 9999)
           mock_group_name(9999, actual_group)
-          expected_message = /expected group to be "testgroup", but was "othergroup"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected group to be "testgroup", but it was "othergroup"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -433,8 +453,10 @@ RSpec.describe 'the be_dir matcher' do
           FileUtils.touch(path)
           mock_file_stat(path, gid: 9999)
           mock_group_name(9999, actual_group)
-          expected_message = /expected group to eq "testgroup", but was "othergroup"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected group to eq "testgroup", but it was "othergroup"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -450,8 +472,10 @@ RSpec.describe 'the be_dir matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `atime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `atime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -474,8 +498,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, atime: actual_atime)
-          expected_message = /expected atime to be #{expected_atime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected atime to be #{expected_atime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -499,8 +525,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, atime: actual_atime)
-          expected_message = /expected atime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected atime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -524,8 +552,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, atime: actual_atime)
-          expected_message = /expected atime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected atime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -555,8 +585,10 @@ RSpec.describe 'the be_dir matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `birthtime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `birthtime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -579,8 +611,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, birthtime: actual_birthtime)
-          expected_message = /expected birthtime to be #{expected_birthtime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected birthtime to be #{expected_birthtime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -604,8 +638,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, birthtime: actual_birthtime)
-          expected_messsage = /expected birthtime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_messsage)
+          expected_message = /expected birthtime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -629,8 +665,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, birthtime: actual_birthtime)
-          expected_message = /expected birthtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected birthtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -646,8 +684,10 @@ RSpec.describe 'the be_dir matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `ctime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `ctime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -670,8 +710,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, ctime: actual_ctime)
-          expected_message = /expected ctime to be #{expected_ctime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected ctime to be #{expected_ctime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -695,8 +737,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, ctime: actual_ctime)
-          expected_message = /expected ctime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected ctime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -720,8 +764,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, ctime: actual_ctime)
-          expected_message = /expected ctime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected ctime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -737,8 +783,10 @@ RSpec.describe 'the be_dir matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `mtime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `mtime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -762,8 +810,10 @@ RSpec.describe 'the be_dir matcher' do
           FileUtils.touch(path)
           mock_file_stat(path, mtime: actual_mtime)
 
-          expected_message = /expected mtime to be #{expected_mtime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mtime to be #{expected_mtime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -787,8 +837,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, mtime: actual_mtime)
-          expected_message = /expected mtime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mtime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -812,8 +864,10 @@ RSpec.describe 'the be_dir matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_stat(path, mtime: actual_mtime)
-          expected_message = /expected mtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -856,7 +910,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected valid JSON content, but got error: /
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -880,7 +936,9 @@ RSpec.describe 'the be_dir matcher' do
       context 'when the expectation is not met' do
         it 'should fail' do
           expected_message = /expected it to exist/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -903,7 +961,9 @@ RSpec.describe 'the be_dir matcher' do
       context 'when the expectation is not met' do
         it 'should fail' do
           expected_message = /expected it to exist/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -936,7 +996,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected it to exist/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -973,7 +1035,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected content to be "content"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -1010,7 +1074,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected file 'entry\.txt' not to be found at '.*', but it exists/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -1043,7 +1109,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected directory 'subdir' not to be found at '.*', but it exists/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -1076,7 +1144,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected symlink 'a_link' not to be found at '.*', but it exists/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -1100,7 +1170,9 @@ RSpec.describe 'the be_dir matcher' do
         # 'good_file.txt' is not created
         it 'should fail' do
           expected_message = /expected it to exist/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
 
@@ -1112,7 +1184,9 @@ RSpec.describe 'the be_dir matcher' do
 
         it 'should fail' do
           expected_message = /expected file 'bad_file\.txt' not to be found at '.*', but it exists/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end

--- a/spec/rspec/path_matchers/be_symlink_spec.rb
+++ b/spec/rspec/path_matchers/be_symlink_spec.rb
@@ -187,7 +187,9 @@ RSpec.describe 'the be_symlink matcher' do
       let(:options) { { invalid_option: true } }
       it 'should raise an ArgumentError' do
         expected_message = /unknown keyword: :invalid_option/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -195,7 +197,9 @@ RSpec.describe 'the be_symlink matcher' do
       let(:options) { { invalid_option: true, another_invalid: false } }
       it 'should raise an ArgumentError listing all invalid options' do
         expected_message = /unknown keywords: :invalid_option, :another_invalid/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
   end
@@ -209,8 +213,10 @@ RSpec.describe 'the be_symlink matcher' do
       let(:expected_owner) { 123 }
 
       it 'should raise an ArgumentError' do
-        expected_message = /expected `owner:` to be a Matcher or String, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `owner:` to be a Matcher or String, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -252,8 +258,10 @@ RSpec.describe 'the be_symlink matcher' do
           FileUtils.touch(path)
           mock_file_lstat(path, uid: 9999)
           mock_user_name(9999, actual_owner)
-          expected_message = /expected owner to be "testuser", but was "otheruser"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected owner to be "testuser", but it was "otheruser"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -279,8 +287,10 @@ RSpec.describe 'the be_symlink matcher' do
           FileUtils.touch(path)
           mock_file_lstat(path, uid: 9999)
           mock_user_name(9999, actual_owner)
-          expected_message = /expected owner to eq "testuser", but was "otheruser"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected owner to eq "testuser", but it was "otheruser"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -294,8 +304,10 @@ RSpec.describe 'the be_symlink matcher' do
     context 'when given an invalid group value' do
       let(:expected_group) { 123 }
       it 'should raise an ArgumentError' do
-        expected_message = /expected `group:` to be a Matcher or String, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `group:` to be a Matcher or String, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -336,8 +348,10 @@ RSpec.describe 'the be_symlink matcher' do
           FileUtils.touch(path)
           mock_file_lstat(path, gid: 9999)
           mock_group_name(9999, actual_group)
-          expected_message = /expected group to be "testgroup", but was "othergroup"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected group to be "testgroup", but it was "othergroup"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -363,8 +377,10 @@ RSpec.describe 'the be_symlink matcher' do
           FileUtils.touch(path)
           mock_file_lstat(path, gid: 9999)
           mock_group_name(9999, actual_group)
-          expected_message = /expected group to eq "testgroup", but was "othergroup"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected group to eq "testgroup", but it was "othergroup"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -380,8 +396,10 @@ RSpec.describe 'the be_symlink matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `atime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `atime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -404,8 +422,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, atime: actual_atime)
-          expected_message = /expected atime to be #{expected_atime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected atime to be #{expected_atime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -429,8 +449,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, atime: actual_atime)
-          expected_message = /expected atime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected atime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -454,8 +476,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, atime: actual_atime)
-          expected_message = /expected atime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected atime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -485,8 +509,10 @@ RSpec.describe 'the be_symlink matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `birthtime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `birthtime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -509,8 +535,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, birthtime: actual_birthtime)
-          expected_message = /expected birthtime to be #{expected_birthtime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected birthtime to be #{expected_birthtime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -534,8 +562,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, birthtime: actual_birthtime)
-          expected_message = /expected birthtime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected birthtime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -559,8 +589,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, birthtime: actual_birthtime)
-          expected_message = /expected birthtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected birthtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -576,8 +608,10 @@ RSpec.describe 'the be_symlink matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `ctime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `ctime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -600,8 +634,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, ctime: actual_ctime)
-          expected_message = /expected ctime to be #{expected_ctime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected ctime to be #{expected_ctime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -625,8 +661,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, ctime: actual_ctime)
-          expected_message = /expected ctime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected ctime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -650,8 +688,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, ctime: actual_ctime)
-          expected_message = /expected ctime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected ctime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -667,8 +707,10 @@ RSpec.describe 'the be_symlink matcher' do
 
       it 'should raise an ArgumentError' do
         FileUtils.touch(path)
-        expected_message = /expected `mtime:` to be a Matcher, Time, or DateTime, but was "invalid"/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `mtime:` to be a Matcher, Time, or DateTime, but it was "invalid"/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -692,8 +734,10 @@ RSpec.describe 'the be_symlink matcher' do
           FileUtils.touch(path)
           mock_file_lstat(path, mtime: actual_mtime)
 
-          expected_message = /expected mtime to be #{expected_mtime.inspect}, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mtime to be #{expected_mtime.inspect}, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -717,8 +761,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, mtime: actual_mtime)
-          expected_message = /expected mtime to be 1967-03-15 00:16:00 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mtime to be 1967-03-15 00:16:00 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -742,8 +788,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.touch(path)
           mock_file_lstat(path, mtime: actual_mtime)
-          expected_message = /expected mtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but was/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected mtime to be within 10 of 1967-03-15 00:16:00.000000000 -0700, but it was/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -758,8 +806,10 @@ RSpec.describe 'the be_symlink matcher' do
       let(:expected_target) { 123 }
 
       it 'should raise an ArgumentError' do
-        expected_message = /expected `target:` to be a Matcher or String, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `target:` to be a Matcher or String, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -777,8 +827,10 @@ RSpec.describe 'the be_symlink matcher' do
         let(:expected_target) { 'not_target_path' }
 
         it 'should fail' do
-          expected_message = /expected target to be "not_target_path", but was "#{target_path}"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target to be "not_target_path", but it was "#{target_path}"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -798,8 +850,10 @@ RSpec.describe 'the be_symlink matcher' do
 
         it 'should fail' do
           FileUtils.touch(path)
-          expected_message = /expected target to eq "not_the_target", but was #{Regexp.escape(target_path.inspect)}/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target to eq "not_the_target", but it was #{Regexp.escape(target_path.inspect)}/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -814,8 +868,10 @@ RSpec.describe 'the be_symlink matcher' do
       let(:expected_target_type) { 123 }
 
       it 'should raise an ArgumentError' do
-        expected_message = /expected `target_type:` to be a Matcher, String, or Symbol, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `target_type:` to be a Matcher, String, or Symbol, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -828,7 +884,9 @@ RSpec.describe 'the be_symlink matcher' do
 
       it 'should fail' do
         expected_message = /expected the symlink target to exist/
-        expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+        expect { subject }.to raise_error(expectation_not_met_error) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -847,8 +905,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.rm_rf(target_path)
           Dir.mkdir(target_path) # Create a directory instead of a file
-          expected_message = /expected target_type to be "file", but was "directory"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target_type to be "file", but it was "directory"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -867,8 +927,10 @@ RSpec.describe 'the be_symlink matcher' do
         it 'should fail' do
           FileUtils.rm_rf(target_path)
           FileUtils.touch(target_path)
-          expected_message = /expected target_type to be "directory", but was "file"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target_type to be "directory", but it was "file"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -889,8 +951,10 @@ RSpec.describe 'the be_symlink matcher' do
           FileUtils.rm_rf(target_path)
           File.symlink('/tmp', target_path) # Create a symlink to a directory
           regexp_str = Regexp.escape('/^(file|directory)$/')
-          expected_message = /expected target_type to match #{regexp_str}, but was "link"/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target_type to match #{regexp_str}, but it was "link"/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -905,8 +969,10 @@ RSpec.describe 'the be_symlink matcher' do
       let(:expected_target_exist) { 123 }
 
       it 'should raise an ArgumentError' do
-        expected_message = /expected `target_exist:` to be a Matcher, TrueClass, or FalseClass, but was 123/
-        expect { subject }.to raise_error(ArgumentError, expected_message)
+        expected_message = /expected `target_exist:` to be a Matcher, TrueClass, or FalseClass, but it was 123/
+        expect { subject }.to raise_error(ArgumentError) do |error|
+          expect(error.message).to match(expected_message)
+        end
       end
     end
 
@@ -924,8 +990,10 @@ RSpec.describe 'the be_symlink matcher' do
       context 'when the expected target type does not match the actual target type' do
         it 'should fail' do
           FileUtils.rm_rf(target_path)
-          expected_message = /expected target_exist to be true, but was false/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target_exist to be true, but it was false/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end
@@ -944,8 +1012,10 @@ RSpec.describe 'the be_symlink matcher' do
       context 'when the expected target type does not match the actual target type' do
         it 'should fail' do
           FileUtils.rm_rf(target_path)
-          expected_message = /expected target_exist to equal true, but was false/
-          expect { subject }.to raise_error(expectation_not_met_error, expected_message)
+          expected_message = /expected target_exist to equal true, but it was false/
+          expect { subject }.to raise_error(expectation_not_met_error) do |error|
+            expect(error.message).to match(expected_message)
+          end
         end
       end
     end

--- a/spec/rspec/path_matchers/failure_messages_spec.rb
+++ b/spec/rspec/path_matchers/failure_messages_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'failure messages' do
 
       expected_message = <<~MSG.chomp
         #{app_path} was not as expected:
-              expected mode to be "0755", but was "0700"
+              expected mode to be "0755", but it was "0700"
       MSG
       expect(matcher.failure_message).to eq(expected_message)
     end
@@ -48,7 +48,7 @@ RSpec.describe 'failure messages' do
       expected_message = <<~MSG.chomp
         #{app_path} was not as expected:
           - config.yml
-              expected content to be "environment: production", but was "environment: test"
+              expected content to be "environment: production", but it was "environment: test"
       MSG
       expect(matcher.failure_message).to eq(expected_message)
     end
@@ -72,8 +72,8 @@ RSpec.describe 'failure messages' do
       expected_message = <<~MSG.chomp
         #{bin_path} was not as expected:
           - setup
-              expected mode to be "0644", but was "0755"
-              expected owner to be "root", but was "testuser"
+              expected mode to be "0644", but it was "0755"
+              expected owner to be "root", but it was "testuser"
       MSG
       expect(matcher.failure_message).to eq(expected_message)
     end
@@ -112,10 +112,10 @@ RSpec.describe 'failure messages' do
       expected_message = <<~MSG.chomp
         #{base_dir} was not as expected:
           - bin/setup
-              expected mode to be "0644", but was "0755"
-              expected owner to be "root", but was "owner"
+              expected mode to be "0644", but it was "0755"
+              expected owner to be "root", but it was "owner"
           - lib/new_project/version.rb
-              expected content to include "VERSION = \\"0.1.1\\"", but was #{version_rb_content.inspect}
+              expected content to include "VERSION = \\"0.1.1\\"", but it was #{version_rb_content.inspect}
       MSG
       expect(matcher.failure_message).to eq(expected_message)
     end
@@ -135,7 +135,7 @@ RSpec.describe 'failure messages' do
 
       expected_message = <<~MSG.chomp
         #{dist_path} was not as expected:
-              contained unexpected entries ["unexpected.log"]
+              expected no other entries, but found ["unexpected.log"]
       MSG
       expect(matcher.failure_message).to eq(expected_message)
     end


### PR DESCRIPTION
Change 1:

Error messages should consistently use the "expected ... but it ..." format.

Reviewed all error messages in the project.

Change 2:

Changed all tests that have error message expectations from:

```
expect { subject }.to raise_error(ArgumentError, expected_message)
```

to:

```
expect { subject }.to raise_error(ArgumentError) do |error|
  expect(error.message).to match(expected_message)
end
```

so that error messages are diff'd when they don't match.