### PR TITLE
Add Windows build with minimal MRI Ruby to CI matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 # Supported platforms / Ruby versions:
-#  - Ubuntu: MRI (3.2, 3.3, 3.4), TruffleRuby (24), JRuby (9.4)
+#  - Ubuntu: MRI (3.2, 3.3, 3.4)
 #  - Windows: MRI (3.2)
 
 jobs:
@@ -30,6 +30,10 @@ jobs:
         ruby: ["3.2", "3.4"]
         operating-system: [ubuntu-latest]
         fail_on_low_coverage: [true]
+        include:
+          - # Only test with minimal Ruby version on Windows
+            ruby: 3.2
+            operating-system: windows-latest
 
     steps:
       - name: Checkout

--- a/spec/rspec/path_matchers/be_dir_spec.rb
+++ b/spec/rspec/path_matchers/be_dir_spec.rb
@@ -215,6 +215,12 @@ RSpec.describe 'the be_dir matcher' do
   end
 
   describe 'the mode: option' do
+    before(:all) do
+      # :nocov: this line is platform-specific
+      skip 'File mode tests are only applicable on Unix-like platforms' unless UNIX_LIKE_PLATFORM
+      # :nocov:
+    end
+
     subject { expect(path).to be_dir(mode: expected_mode) }
 
     before { FileUtils.mkdir(path) }

--- a/spec/rspec/path_matchers/be_file_spec.rb
+++ b/spec/rspec/path_matchers/be_file_spec.rb
@@ -572,6 +572,12 @@ RSpec.describe 'the be_file matcher' do
   end
 
   describe 'the mode: option' do
+    before(:all) do
+      # :nocov: this line is platform-specific
+      skip 'File mode tests are only applicable on Unix-like platforms' unless UNIX_LIKE_PLATFORM
+      # :nocov:
+    end
+
     subject { expect(path).to be_file(mode: expected_mode) }
 
     before { FileUtils.touch(path) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
 end
 
 # Guard for Unix-specific tests, as Windows does not have the same ownership concepts
-UNIX_PLATFORM = RUBY_PLATFORM !~ /cygwin|mswin|mingw|bccwin|wince|emx/
+UNIX_LIKE_PLATFORM = RUBY_PLATFORM !~ /cygwin|mswin|mingw|bccwin|wince|emx/
 
 # Helper method to get the current user for ownership tests
 def current_user
@@ -66,13 +66,13 @@ end
 def mock_file_stat(
   path,
   atime: mocked_now, birthtime: mocked_now, ctime: mocked_now, mtime: mocked_now,
-  uid: 9999, gid: 9999, mode: 0o644
+  uid: 9999, gid: 9999, mode: 0o644, size: 0
 )
   allow(File).to(
     receive(:stat).with(path).and_return(
       double(
         atime:, birthtime:, ctime:, mtime:,
-        uid:, gid:, mode:
+        uid:, gid:, mode:, size:
       )
     )
   )
@@ -102,7 +102,14 @@ SimpleCov.enable_coverage :branch
 def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
 
 SimpleCov::RSpec.start(list_uncovered_lines: ci_build?) do
-  minimum_coverage line: 100, branch: 100
+  minimum_coverage line: 100, branch: 100 if UNIX_LIKE_PLATFORM
+
+  add_filter '/spec/'
+  add_filter '/vendor/'
+  add_filter '/lib/rspec/path_matchers/version.rb'
+  add_filter '/lib/rspec/path_matchers/cli.rb'
+  add_filter '/lib/rspec/path_matchers/cli_options.rb'
+  add_filter '/lib/rspec/path_matchers/cli_parser.rb'
 end
 
 require 'rspec/path_matchers'


### PR DESCRIPTION
Introduce a Windows build configuration to the Continuous Integration setup, specifically testing with the minimal MRI Ruby version.